### PR TITLE
add outputFolder for documentation generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Default phase : *package*
 | parameter name | required | description                                                  |
 | -------------- | -------- | ------------------------------------------------------------ |
 | configFile     | yes      | The path to mkdocs configuration file (usually "mkdocs.yml") |
+| outputFolder   | no       | The output folder where the documentation is generated in    |
 
 ```xml
 <plugin>
@@ -30,6 +31,7 @@ Default phase : *package*
             </goals>
             <configuration>
                 <configFile>${basedir}/src/site/documentation/mkdocs.yml</configFile>
+                <outputFolder>{directoryOfYourChoice}</outputFolder>
             </configuration>
         </execution>
     </executions>

--- a/src/main/java/com/github/fabienbarbero/plugins/mkdocs/MkdocsBuildMojo.java
+++ b/src/main/java/com/github/fabienbarbero/plugins/mkdocs/MkdocsBuildMojo.java
@@ -53,6 +53,9 @@ public class MkdocsBuildMojo
     @Parameter( readonly = true, defaultValue = "${project}" )
     private MavenProject project;
 
+    @Parameter
+    private File outputFolder;
+
     @Component
     private MavenProjectHelper helper;
 
@@ -62,7 +65,7 @@ public class MkdocsBuildMojo
     {
         try {
             // Create output dir
-            Path outputDir = projectBuildDir.toPath().resolve( "mkdocs/" + mojoExecution.getExecutionId() );
+            Path outputDir = projectBuildDir.toPath().resolve( outputFolder == null ? "mkdocs/" + mojoExecution.getExecutionId() : outputFolder.toString() );
             if ( Files.notExists( outputDir ) ) {
                 Files.createDirectories( outputDir );
             }


### PR DESCRIPTION
In case the documentation should be generated into a different folder than default.